### PR TITLE
Fix logger import error by falling back to stdlib logging

### DIFF
--- a/src/autotrain/logging.py
+++ b/src/autotrain/logging.py
@@ -1,7 +1,13 @@
 import sys
+import logging
 from dataclasses import dataclass
 
-from loguru import logger
+try:
+    from loguru import logger as _loguru_logger
+    LOGURU_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - fallback when loguru is missing
+    LOGURU_AVAILABLE = False
+    _loguru_logger = logging.getLogger("autotrain")
 
 
 IS_ACCELERATE_AVAILABLE = False
@@ -35,13 +41,19 @@ class Logger:
     """
 
     def __post_init__(self):
-        self.log_format = (
-            "<level>{level: <8}</level> | "
-            "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
-            "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
-            "<level>{message}</level>"
-        )
-        self.logger = logger
+        if LOGURU_AVAILABLE:
+            self.log_format = (
+                "<level>{level: <8}</level> | "
+                "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+                "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
+                "<level>{message}</level>"
+            )
+        else:
+            self.log_format = (
+                "%(levelname)-8s | %(asctime)s | %(name)s:%(funcName)s:%(lineno)d - "
+                "%(message)s"
+            )
+        self.logger = _loguru_logger
         self.setup_logger()
 
     def _should_log(self, record):
@@ -50,12 +62,19 @@ class Logger:
         return PartialState().is_main_process
 
     def setup_logger(self):
-        self.logger.remove()
-        self.logger.add(
-            sys.stdout,
-            format=self.log_format,
-            filter=lambda x: self._should_log(x) if IS_ACCELERATE_AVAILABLE else None,
-        )
+        if LOGURU_AVAILABLE:
+            self.logger.remove()
+            self.logger.add(
+                sys.stdout,
+                format=self.log_format,
+                filter=lambda x: self._should_log(x) if IS_ACCELERATE_AVAILABLE else None,
+            )
+        else:
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setFormatter(logging.Formatter(self.log_format))
+            if not self.logger.handlers:
+                self.logger.addHandler(handler)
+            self.logger.setLevel(logging.INFO)
 
     def get_logger(self):
         return self.logger


### PR DESCRIPTION
## Summary
- allow `src/autotrain/logging.py` to run without `loguru`
- tests now run without extra dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684154524cc483229618695ee58e1706